### PR TITLE
app no longer stays alive after closing all windows

### DIFF
--- a/main.js
+++ b/main.js
@@ -143,7 +143,7 @@ const mainMenuTemplate = [{
 }];
 //Close when window is closed
 app.on('window-all-closed', function(){
-    if(process.platform !== 'win32'){ //If there is no win32.
+    if(process.platform !== 'darwin'){ // if your system is other than MacOS
       app.quit();//Quit the desktop app completely.
     }
 });


### PR DESCRIPTION
It was closing the app correctly for systems other an Windows, now works like it should (on macos most apps do not quit when window is closed, it works fine now)